### PR TITLE
Fix Bad state: NoSuchMethodError: The getter 'length' was called on n…

### DIFF
--- a/lib/src/executable.dart
+++ b/lib/src/executable.dart
@@ -11,20 +11,32 @@ abstract class Executable<T> {
   final SendPort _sendPort;
 
   U instanceOf<U>(String typeName,
-      {List positionalArguments: const [], Map<Symbol, dynamic> namedArguments, Symbol constructorName}) {
-    ClassMirror typeMirror = currentMirrorSystem().isolate.rootLibrary.declarations[new Symbol(typeName)];
+      {List positionalArguments: const [],
+      Map<Symbol, dynamic> namedArguments = const <Symbol, dynamic>{},
+      Symbol constructorName}) {
+    ClassMirror typeMirror = currentMirrorSystem()
+        .isolate
+        .rootLibrary
+        .declarations[new Symbol(typeName)];
     if (typeMirror == null) {
       typeMirror = currentMirrorSystem()
           .libraries
           .values
-          .where((lib) => lib.uri.scheme == "package" || lib.uri.scheme == "file")
+          .where(
+              (lib) => lib.uri.scheme == "package" || lib.uri.scheme == "file")
           .expand((lib) => lib.declarations.values)
-          .firstWhere((decl) => decl is ClassMirror && MirrorSystem.getName(decl.simpleName) == typeName,
-              orElse: () => throw new ArgumentError("Unknown type '$typeName'. Did you forget to import it?"));
+          .firstWhere(
+              (decl) =>
+                  decl is ClassMirror &&
+                  MirrorSystem.getName(decl.simpleName) == typeName,
+              orElse: () => throw new ArgumentError(
+                  "Unknown type '$typeName'. Did you forget to import it?"));
     }
 
-    return typeMirror.newInstance(constructorName ?? const Symbol(""), positionalArguments, namedArguments).reflectee
-        as U;
+    return typeMirror
+        .newInstance(constructorName ?? const Symbol(""), positionalArguments,
+            namedArguments)
+        .reflectee as U;
   }
 
   void send(dynamic message) {

--- a/lib/src/source_generator.dart
+++ b/lib/src/source_generator.dart
@@ -3,15 +3,20 @@ import 'dart:isolate';
 import 'dart:mirrors';
 import 'dart:async';
 
-import 'package:analyzer/analyzer.dart';
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/analysis/features.dart';
+import 'package:analyzer/dart/analysis/utilities.dart';
 import 'package:isolate_executor/src/executable.dart';
+import 'package:pub_semver/pub_semver.dart';
 
 class SourceGenerator {
-  SourceGenerator(this.executableType, {this.imports, this.additionalContents, this.additionalTypes});
+  SourceGenerator(this.executableType,
+      {this.imports, this.additionalContents, this.additionalTypes});
 
   Type executableType;
 
-  String get typeName => MirrorSystem.getName(reflectType(executableType).simpleName);
+  String get typeName =>
+      MirrorSystem.getName(reflectType(executableType).simpleName);
   final List<String> imports;
   final String additionalContents;
   final List<Type> additionalTypes;
@@ -50,11 +55,15 @@ Future main (List<String> args, Map<String, dynamic> message) async {
   }
 
   static Future<ClassDeclaration> _getClass(Type type) async {
-    final uri = await Isolate.resolvePackageUri(reflectClass(type).location.sourceUri);
-    final fileUnit = parseDartFile(uri.toFilePath(windows: Platform.isWindows));
+    final uri =
+        await Isolate.resolvePackageUri(reflectClass(type).location.sourceUri);
+    final fileUnit = parseFile(
+        path: uri.toFilePath(windows: Platform.isWindows),
+        featureSet: FeatureSet.fromEnableFlags2(
+            flags: [], sdkLanguageVersion: Version(2, 8, 0)));
     final typeName = MirrorSystem.getName(reflectClass(type).simpleName);
 
-    return fileUnit.declarations
+    return fileUnit.unit.declarations
         .where((u) => u is ClassDeclaration)
         .map((cu) => cu as ClassDeclaration)
         .firstWhere((classDecl) => classDecl.name.name == typeName);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   sdk: ">=2.0.0 <3.0.0"
 
 dependencies:
-  analyzer: '>=0.32.0 <0.50.0'
+  analyzer: '>=0.40.6 <0.41.0'
 
 dev_dependencies:
   test: ^1.3.0


### PR DESCRIPTION
…ull.

The issue makes aqueduct db generate crash 100% of the time if you use a version of dart > 2.8.

You need to merge and release a version of isolate-executor and aqueduct ASAP to fix the issue dating from june.